### PR TITLE
Added togglable visibility for twitch user ID

### DIFF
--- a/tau/templates/base.html
+++ b/tau/templates/base.html
@@ -5,8 +5,7 @@
 <head>
   <meta charset="utf-8">
   <title>{% block title %}{% endblock %}</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.3.0/font/bootstrap-icons.css">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/themes/prism.min.css" integrity="sha512-tN7Ec6zAFaVSG3TpNAKtk4DOHNpSwKHxxrsiw4GHKESGPs5njn/0sMCUMl2svV4wo4BK/rCP7juYz+zx+l6oeQ==" crossorigin="anonymous" />
   <link rel="stylesheet" href="{% static 'css/app.css' %}" type="text/css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.1/font/bootstrap-icons.css">
@@ -68,7 +67,11 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/plugins/autoloader/prism-autoloader.min.js"
     integrity="sha512-zc7WDnCM3aom2EziyDIRAtQg1mVXLdILE09Bo+aE1xk0AM2c2cVLfSW9NrxE5tKTX44WBY0Z2HClZ05ur9vB6A=="
     crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
+  <script
+    src="https://code.jquery.com/jquery-3.6.0.min.js"
+    integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4="
+    crossorigin="anonymous"></script>
   <script src="{% static 'js/app.js' %}"></script>
   <script src="{% static 'js/update.js' %}"></script>
   <script src="{% static 'js/cheers.js' %}"></script>

--- a/tau/templates/modal-forms/cheers-modal.html
+++ b/tau/templates/modal-forms/cheers-modal.html
@@ -9,7 +9,7 @@
             <form id="channel-cheer-test">
                 <div class="col-12">
                   <label for="cheer-username" class="form-label">Username</label>
-                  <div class="input-group">
+                  <div class="input-group mb-3">
                     <input
                       type="text"
                       class="form-control"
@@ -18,18 +18,13 @@
                       required
                       onblur="getUserId('cheer-username', 'cheer-user-id')"
                       >
-                  <div class="invalid-feedback">
-                      A username is required.
-                    </div>
                   </div>
                 </div>
                 <div class="col-12">
                   <label for="cheer-user-id" class="form-label">User ID</label>
-                  <div class="input-group">
-                    <input type="text" class="form-control" id="cheer-user-id" placeholder="User ID" required>
-                  <div class="invalid-feedback">
-                      A User ID is required.
-                    </div>
+                  <div class="input-group mb-3">
+                    <input type="password" class="form-control" id="cheer-user-id" placeholder="User ID" required>
+                    <button class="btn btn-secondary" type="button" onclick="toggleVisibility(this)"><i class="bi bi-eye"></i></button>
                   </div>
                 </div>
                 <div class="col-12">
@@ -43,11 +38,8 @@
                 </div>
                 <div class="col-12">
                   <label for="message" class="form-label">Message</label>
-                  <div class="input-group">
+                  <div class="input-group mb-3">
                     <input type="text" class="form-control" id="message" placeholder="Message..." required>
-                  <div class="invalid-feedback">
-                      Message is required.
-                    </div>
                   </div>
                 </div>
                 <div class="form-check">

--- a/tau/templates/modal-forms/follow-modal.html
+++ b/tau/templates/modal-forms/follow-modal.html
@@ -9,7 +9,7 @@
             <form id="channel-follow-test">
                 <div class="col-12">
                   <label for="username" class="form-label">Username</label>
-                  <div class="input-group">
+                  <div class="input-group mb-3">
                     <input 
                       type="text"
                       class="form-control"
@@ -17,18 +17,13 @@
                       placeholder="Username"
                       required
                       onblur="getUserId('follow-username', 'follow-user-id')">
-                  <div class="invalid-feedback">
-                      A username is required.
-                    </div>
                   </div>
                 </div>
                 <div class="col-12">
                   <label for="follow-user-id" class="form-label">User ID</label>
-                  <div class="input-group">
-                    <input type="text" class="form-control" id="follow-user-id" placeholder="User ID" required>
-                  <div class="invalid-feedback">
-                      A User ID is required.
-                    </div>
+                  <div class="input-group mb-3">
+                    <input type="password" class="form-control" id="follow-user-id" placeholder="User ID" required>
+                    <button class="btn btn-secondary" type="button" onclick="toggleVisibility(this)"><i class="bi bi-eye"></i></button>
                   </div>
                 </div>
               </form>

--- a/tau/templates/modal-forms/points-redemption-modal.html
+++ b/tau/templates/modal-forms/points-redemption-modal.html
@@ -9,32 +9,23 @@
             <form id="channel-points-redemption-test">
                 <div class="col-12">
                   <label for="username" class="form-label">Username</label>
-                  <div class="input-group">
+                  <div class="input-group mb-3">
                     <input type="text" class="form-control" id="username" placeholder="Username" required>
-                  <div class="invalid-feedback">
-                      A username is required.
-                    </div>
                   </div>
                 </div>
                 <div class="col-12">
                   <label for="reward" class="form-label">Reward</label>
-                  <div class="input-group">
+                  <div class="input-group mb-3">
                     <select class="form-select" id="reward" required>
                         <option value="">Choose...</option>
                         <option value="575c2991-cbc2-402c-837f-86bd40009379">Test</option>
                       </select>
-                  <div class="invalid-feedback">
-                      Reward is required.
-                    </div>
                   </div>
                 </div>
                 <div class="col-12">
                     <label for="user_input" class="form-label">User Input</label>
-                    <div class="input-group">
+                    <div class="input-group mb-3">
                       <input type="text" class="form-control" id="user_input" placeholder="User Input" required>
-                    <div class="invalid-feedback">
-                        A user input is required.
-                      </div>
                     </div>
                 </div>
               </form>

--- a/tau/templates/modal-forms/raid-modal.html
+++ b/tau/templates/modal-forms/raid-modal.html
@@ -9,7 +9,7 @@
             <form id="channel-raid-test">
                 <div class="col-12">
                   <label for="raid-from_broadcaster_user_name" class="form-label">Raider</label>
-                  <div class="input-group">
+                  <div class="input-group mb-3">
                     <input
                       type="text"
                       class="form-control"
@@ -18,27 +18,19 @@
                       required
                       onblur="getUserId('raid-from_broadcaster_user_name', 'raid-from_broadcaster_user_id')"
                     >
-                  <div class="invalid-feedback">
-                      A raider is required.
-                    </div>
                   </div>
                 </div>
                 <div class="col-12">
                   <label for="raid-from_broadcaster_user_id" class="form-label">Raider ID</label>
-                  <div class="input-group">
-                    <input type="text" class="form-control" id="raid-from_broadcaster_user_id" placeholder="Raider ID" required>
-                  <div class="invalid-feedback">
-                      A raider ID is required.
-                    </div>
+                  <div class="input-group mb-3">
+                    <input type="password" class="form-control" id="raid-from_broadcaster_user_id" placeholder="Raider ID" required>
+                    <button class="btn btn-secondary" type="button" onclick="toggleVisibility(this)"><i class="bi bi-eye"></i></button>
                   </div>
                 </div>
                 <div class="col-12">
                   <label for="viewers" class="form-label">Viewers</label>
-                  <div class="input-group">
+                  <div class="input-group mb-3">
                     <input type="number" class="form-control" id="viewers" placeholder="Viewers" required>
-                  <div class="invalid-feedback">
-                      Viewers is required.
-                    </div>
                   </div>
                 </div>
               </form>

--- a/tau/templates/modal-forms/subs-modal.html
+++ b/tau/templates/modal-forms/subs-modal.html
@@ -9,7 +9,7 @@
             <form id="channel-sub-test">
                 <div class="col-12">
                   <label for="sub-username" class="form-label">Username</label>
-                  <div class="input-group">
+                  <div class="input-group mb-3">
                     <input
                       type="text"
                       class="form-control"
@@ -17,23 +17,18 @@
                       placeholder="Username"
                       required
                       onblur="getUserId('sub-username', 'sub-user-id')">
-                    <div class="invalid-feedback">
-                      A username is required.
-                    </div>
                   </div>
                 </div>
                 <div class="col-12">
                   <label for="sub-user-id" class="form-label">User ID</label>
-                  <div class="input-group">
-                    <input type="text" class="form-control" id="sub-user-id" placeholder="User ID" required>
-                  <div class="invalid-feedback">
-                      A User ID is required.
-                    </div>
+                  <div class="input-group mb-3">
+                    <input type="password" class="form-control" id="sub-user-id" placeholder="User ID" required>
+                    <button class="btn btn-secondary" type="button" onclick="toggleVisibility(this)"><i class="bi bi-eye"></i></button>
                   </div>
                 </div>
                 <div class="col-12">
                   <label for="tier" class="form-label">Tier</label>
-                  <div class="input-group">
+                  <div class="input-group mb-3">
                     <select class="form-control" id="tier" required>
                       <option value="1000">Tier 1</option>
                       <option value="2000">Tier 2</option>
@@ -41,35 +36,23 @@
                       <option value="prime">Prime</option>
                     </select>
                   </div>
-                  <div class="invalid-feedback">
-                    A tier is required.
-                  </div>
                 </div>
                 <div class="col-12">
                   <label for="message" class="form-label">Message</label>
-                  <div class="input-group">
+                  <div class="input-group mb-3">
                     <input type="text" class="form-control" id="message" placeholder="Message..." required>
-                  <div class="invalid-feedback">
-                      Message is required.
-                    </div>
                   </div>
                 </div>
                 <div class="col-12">
                   <label for="cumulative_months" class="form-label">Cumulative Months</label>
-                  <div class="input-group">
+                  <div class="input-group mb-3">
                     <input type="number" class="form-control" id="cumulative_months" placeholder="Cumulative Months" required>
-                  <div class="invalid-feedback">
-                      Cumulative Months is required.
-                    </div>
                   </div>
                 </div>
                 <div class="col-12">
                   <label for="streak_months" class="form-label">Streak Months</label>
-                  <div class="input-group">
+                  <div class="input-group mb-3">
                     <input type="number" class="form-control" id="streak_months" placeholder="Streak Months" required>
-                  <div class="invalid-feedback">
-                      Streak Months is required.
-                    </div>
                   </div>
                 </div>
               </form>

--- a/tau/templates/static/js/app.js
+++ b/tau/templates/static/js/app.js
@@ -190,3 +190,14 @@ const getUserId = (username_id, userid_id) => {
         }
     });
 }
+
+
+const toggleVisibility = (ele) => {
+    ele = $(ele);
+    const i = $(ele.children()[0]);
+    i.toggleClass('bi-eye');
+    i.toggleClass('bi-eye-slash');
+    const input = $(ele.siblings()[0]);
+    const inputType = input.prop('type') === 'password' ? 'text' : 'password';
+    input.prop('type', inputType);
+}


### PR DESCRIPTION
Adds a toggle to all twitch user ID fields to toggle between a normal text input, and a password input to obscure the user ID.  By default the field is password/obscured.  Closes issue #17 .