### PR TITLE
Lock the database and redis image to specific tags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   
   db:
-    image: postgres:latest
+    image: postgres:13-alpine
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data
@@ -45,7 +45,7 @@ services:
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
   redis:
-    image: redis:alpine
+    image: redis:6-alpine
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
Closes #41, Locking the [postgres](https://hub.docker.com/_/postgres) and [redis](https://hub.docker.com/_/redis) images to specific major versions using the alpine image.  Based on semver, it should be safe to lock the image to just the major version instead of major.minor.

I have tested the change against my instance of TAU, and converting from postgres:latest -> postgres:13-alpine, as well as redis:alpine->redis:6-alpine was safe and worked fine with a simple compose down then compose up.  Granted redis:alpine and redis:6-alpine are the same right now but come redis 7 there would be a difference which could cause breaking down the line.