### PR TITLE
Support reverse proxy and writeup some documentation

### DIFF
--- a/docs/env_options.md
+++ b/docs/env_options.md
@@ -1,0 +1,24 @@
+# Environment Variables
+
+The following environment variables can be used to manipulate your Tau install.
+
+| Key                   | Description                                                                      | Default Value |
+|-----------------------|----------------------------------------------------------------------------------|---------------|
+| PUBLIC_URL            | Hostname used to communicate with TAU                                            | localhost     |
+| PROTOCOL              | Protocol being used, either "http:" or "https:"                                  | http:         |
+| PORT                  | Port for the application to listen on                                            | 8000          |
+| BEHIND_PROXY          | Whether or not the application is running behind a reverse proxy (like NGINX)    | False         |
+| USE_NGROK             | Whether or not to use NGROK to allow running TAU locally without port forwarding | False         |
+| NGROK_TOKEN           | Token used for authenticating with NGROK                                         | ''            |
+| REDIS_ENDPOINT        | Address and Port to connect to Redis at                                          | redis:6379    |
+| REDIS_PW              | Password used to authenticate with Redis                                         | ''            |
+| DJANGO_DB_TYPE        | Database types django uses, options are `postgres` and `sqlite`                  | postgres      |
+| DJANGO_DB             | Name of the database                                                             | tau_db        |
+| DJANGO_DB_URL         | Hostname of the database                                                         | db            |
+| DJANGO_DB_USER        | Username to connect to the database with                                         | tau_db        |
+| DJANGO_DB_PW          | Password for the `DJANGO_DB_USER`                                                | ''            |
+| DJANGO_CONFIGURATION  | Configuration django uses                                                        | Local         |
+| DJANGO_SECRET_KEY     | Key used by Django for keeping your data stored securely                         | None          |
+| TWITCH_APP_ID         | Application ID for connecting to twitch                                          | ''            |
+| TWITCH_CLIENT_SECRET  | Used for communicating with the twitch API                                       | ''            |
+| TWITCH_WEBHOOK_SECRET | Used for signing the webhooks from twitch to validate they are legitimate        | ''            |

--- a/tau/config/common.py
+++ b/tau/config/common.py
@@ -11,9 +11,9 @@ class Common(Configuration):  # pylint: disable=no-init
     PROTOCOL = os.environ.get("PROTOCOL", "http:")
     BASE_PORT = int(os.environ.get("PORT", 8000))
     BASE_URL = f"{PROTOCOL}//{PUBLIC_URL}"
-    
+    BEHIND_PROXY = (os.environ.get("BEHIND_PROXY", "false").lower() == "true")
 
-    if BASE_PORT not in [80, 443]:
+    if BASE_PORT not in [80, 443] and not BEHIND_PROXY:
         BASE_URL = BASE_URL + f":{BASE_PORT}"
 
     IS_SERVER = len(sys.argv) > 1 and "shell" not in sys.argv


### PR DESCRIPTION
Support a reverse proxy by not overriding the BASE_URL appending the (internal) port to the request if it's behind a proxy.  This will allow the reverse proxy to work properly and not cause Tau to try to include the internal port for requests to twitch for the callback.

Also wrote up some documentation on various environment variables that are available to the administrator (including the new one)